### PR TITLE
Parameterise Anaconda install

### DIFF
--- a/anaconda-choco/anaconda2/Versions/5.0.0/anaconda2.nuspec
+++ b/anaconda-choco/anaconda2/Versions/5.0.0/anaconda2.nuspec
@@ -10,12 +10,17 @@
     <owners>Chantisnake</owners>
     <summary>a python distribution created by continuum</summary>
     <description>
-        a python distribution created by continuum
-        this installation:
-          1. will not add anaconda python to path,
-          2. will register anaconda python at defualt python2
-          3. will install for all user
-          4. will install in your `$ToolsDir\Anaconda2` (`$ToolsDir` is the path returned by `Get-ToolsLocation`) default is `C:\Tools\Anaconda3`
+A Python distribution created by Continuum
+By default, this installation:
+  * will not add anaconda python to path,
+  * will register anaconda python at default python3
+  * will install for all users
+  * will install in your `$ToolsDir\Anaconda3` (`$ToolsDir` is the path returned by `Get-ToolsLocation`) default is `C:\Tools\`
+You can provide parameters for the install, per Anaconda docs at https://conda.io/docs/user-guide/install/windows.html
+  */InstallationType:[AllUsers|JustMe]
+  */AddToPath:[0|1]
+  */RegisterPython:[0|1]
+  */D:(installation path)
     </description>
     <projectUrl>https://www.continuum.io/why-anaconda</projectUrl>
     <packageSourceUrl>https://github.com/chantisnake/chocolateyPackage/tree/master/anaconda-choco/anaconda3</packageSourceUrl>

--- a/anaconda-choco/anaconda2/Versions/5.0.0/anaconda2.nuspec
+++ b/anaconda-choco/anaconda2/Versions/5.0.0/anaconda2.nuspec
@@ -12,15 +12,18 @@
     <description>
 A Python distribution created by Continuum
 By default, this installation:
+
   * will not add anaconda python to path,
-  * will register anaconda python at default python3
+  * will register anaconda python as default python2
   * will install for all users
   * will install in your `$ToolsDir\Anaconda3` (`$ToolsDir` is the path returned by `Get-ToolsLocation`) default is `C:\Tools\`
+
 You can provide parameters for the install, per Anaconda docs at https://conda.io/docs/user-guide/install/windows.html
-  */InstallationType:[AllUsers|JustMe]
-  */AddToPath:[0|1]
-  */RegisterPython:[0|1]
-  */D:(installation path)
+
+  * /InstallationType:[AllUsers|JustMe]
+  * /AddToPath:[0|1]
+  * /RegisterPython:[0|1]
+  * /D:(installation path)
     </description>
     <projectUrl>https://www.continuum.io/why-anaconda</projectUrl>
     <packageSourceUrl>https://github.com/chantisnake/chocolateyPackage/tree/master/anaconda-choco/anaconda3</packageSourceUrl>
@@ -34,6 +37,9 @@ You can provide parameters for the install, per Anaconda docs at https://conda.i
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <iconUrl>https://raw.githubusercontent.com/chantisnake/anaconda_choco/master/logo-anaconda.png</iconUrl>
     <releaseNotes></releaseNotes>
+    <dependencies>
+      <dependency id="chocolatey-core.extension" version="1.1.0" />
+    </dependencies>
   </metadata>
   <files>
     <file src="tools\chocolateyinstall.ps1" target="tools" />

--- a/anaconda-choco/anaconda2/Versions/5.0.0/tools/chocolateyinstall.ps1
+++ b/anaconda-choco/anaconda2/Versions/5.0.0/tools/chocolateyinstall.ps1
@@ -1,4 +1,4 @@
-﻿$ErrorActionPreference = 'Stop';
+﻿$ErrorActionPreference = 'Stop'
  
  
 $packageName= 'anaconda2'
@@ -64,10 +64,10 @@ $packageArgs = @{
   checksumType64= 'sha256'
 }
  
-Write-Host 'installing anaconda2, this can take a long time, because the installer will write tons of files on your disk' -ForegroundColor Magenta
-Write-Host 'Please sit back and relax' -ForegroundColor Magenta
-Write-Host 'This usually will take 10-15 mins on an SSD, and about 30 mins on HDD' -ForegroundColor Magenta
-Write-Host ''
-Write-Host 'If you want to make sure the program is running, you can open Task Manager' -ForegroundColor Magenta
-Write-Host 'you will find the installer running in Background Process' -ForegroundColor Magenta
+Write-Warning 'installing anaconda3, this can take a long time, because the installer will write tons of files on your disk'
+Write-Warning 'Please sit back and relax'
+Write-Warning 'This usually will take 10-15 mins on an SSD, and about 30 mins on HDD'
+Write-Warning ''
+Write-Warning 'If you want to make sure the program is running, you can open Task Manager'
+Write-Warning 'you will find the installer running in Background Process'
 Install-ChocolateyPackage @packageArgs

--- a/anaconda-choco/anaconda2/Versions/5.0.0/tools/chocolateyinstall.ps1
+++ b/anaconda-choco/anaconda2/Versions/5.0.0/tools/chocolateyinstall.ps1
@@ -5,6 +5,48 @@ $packageName= 'anaconda2'
 $url        = 'http://repo.continuum.io/archive/Anaconda2-5.0.0-Windows-x86.exe'
 $url64      = 'http://repo.continuum.io/archive/Anaconda2-5.0.0-Windows-x86_64.exe'
 $ToolsDir   = Get-ToolsLocation
+
+$pp = Get-PackageParameters
+
+if (!$pp['InstallationType']) {
+    $InstallationType = 'AllUsers'
+} else {
+    if ($pp['InstallationType'] -notin 'AllUsers','JustMe') {
+        Write-Error "Value for InstallationType not recognised: only `'AllUsers`' or `'JustMe`' are valid"
+    } else {
+        $InstallationType = $pp['InstallationType']
+    }
+}
+
+if (!$pp['RegisterPython']) {
+    $RegisterPython = '1'
+} else {
+    if ($pp['RegisterPython'] -notin '0','1') {
+        Write-Error "Value for RegisterPython not recognised: only `'0`' or `'1`' are valid"
+    } else {
+        $RegisterPython = $pp['RegisterPython']
+    }
+}
+
+if (!$pp['AddToPath']) {
+    $AddToPath = '0'
+} else {
+    if ($pp['AddToPath'] -notin '0','1') {
+        Write-Error "Value for AddToPath not recognised: only `'0`' or `'1`' are valid"
+    } else {
+        $AddToPath = $pp['AddToPath']
+    }
+}
+
+if (!$pp['D']) {
+    $D = Join-Path $ToolsDir 'Anaconda2'
+} else {
+    if (!(Test-Path -IsValid $pp['D'])) {
+        Write-Error "Value for D ($($pp['D'])) is not a valid directory path"
+    } else {
+        $D = $pp['D']
+    }
+}
  
 $packageArgs = @{
   packageName   = $packageName
@@ -12,7 +54,7 @@ $packageArgs = @{
   url           = $url
   url64bit      = $url64
  
-  silentArgs    = "/S /InstallationType=AllUsers /RegisterPython=1 /AddToPath=0 /D=$(Join-Path $ToolsDir 'Anaconda2')"
+  silentArgs    = "/S /InstallationType=$InstallationType /RegisterPython=$RegisterPython /AddToPath=$AddToPath /D=$D"
   validExitCodes= @(0)
  
   softwareName  = 'Anaconda2'

--- a/anaconda-choco/anaconda2/Versions/5.0.0/tools/chocolateyinstall.ps1
+++ b/anaconda-choco/anaconda2/Versions/5.0.0/tools/chocolateyinstall.ps1
@@ -64,7 +64,7 @@ $packageArgs = @{
   checksumType64= 'sha256'
 }
  
-Write-Warning 'installing anaconda3, this can take a long time, because the installer will write tons of files on your disk'
+Write-Warning 'installing anaconda2, this can take a long time, because the installer will write tons of files on your disk'
 Write-Warning 'Please sit back and relax'
 Write-Warning 'This usually will take 10-15 mins on an SSD, and about 30 mins on HDD'
 Write-Warning ''

--- a/anaconda-choco/anaconda3/Versions/5.0.0/anaconda3.nuspec
+++ b/anaconda-choco/anaconda3/Versions/5.0.0/anaconda3.nuspec
@@ -8,19 +8,22 @@
     <version>5.0.0</version>
     <authors>Continuum</authors>
     <owners>Chantisnake</owners>
-    <summary> a python distribution created by continuum</summary>
-<description>
+    <summary>a python distribution created by continuum</summary>
+    <description>
 A Python distribution created by Continuum
 By default, this installation:
+
   * will not add anaconda python to path,
   * will register anaconda python at default python3
   * will install for all users
   * will install in your `$ToolsDir\Anaconda3` (`$ToolsDir` is the path returned by `Get-ToolsLocation`) default is `C:\Tools\`
+  
 You can provide parameters for the install, per Anaconda docs at https://conda.io/docs/user-guide/install/windows.html
-  */InstallationType:[AllUsers|JustMe]
-  */AddToPath:[0|1]
-  */RegisterPython:[0|1]
-  */D:(installation path)
+
+  * /InstallationType:[AllUsers|JustMe]
+  * /AddToPath:[0|1]
+  * /RegisterPython:[0|1]
+  * /D:(installation path)
     </description>
     <projectUrl>https://www.continuum.io/why-anaconda</projectUrl>
     <packageSourceUrl>https://github.com/chantisnake/chocolateyPackage/tree/master/anaconda-choco/anaconda3</packageSourceUrl>
@@ -34,6 +37,9 @@ You can provide parameters for the install, per Anaconda docs at https://conda.i
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://github.com/chantisnake/chocolateyPackage/raw/master/anaconda-choco/logo-anaconda.png</iconUrl>
     <releaseNotes></releaseNotes>
+    <dependencies>
+      <dependency id="chocolatey-core.extension" version="1.1.0" />
+    </dependencies>
   </metadata>
   <files>
     <file src="tools\chocolateyinstall.ps1" target="tools" />

--- a/anaconda-choco/anaconda3/Versions/5.0.0/anaconda3.nuspec
+++ b/anaconda-choco/anaconda3/Versions/5.0.0/anaconda3.nuspec
@@ -9,13 +9,18 @@
     <authors>Continuum</authors>
     <owners>Chantisnake</owners>
     <summary> a python distribution created by continuum</summary>
-    <description>
-        a python distribution created by continuum
-        this installation:
-          1. will not add anaconda python to path,
-          2. will register anaconda python at defualt python3
-          3. will install for all user
-          4. will install in your `$ToolsDir\Anaconda3` (`$ToolsDir` is the path returned by `Get-ToolsLocation`) default is `C:\Tools\Anaconda3`
+<description>
+A Python distribution created by Continuum
+By default, this installation:
+  * will not add anaconda python to path,
+  * will register anaconda python at default python3
+  * will install for all users
+  * will install in your `$ToolsDir\Anaconda3` (`$ToolsDir` is the path returned by `Get-ToolsLocation`) default is `C:\Tools\`
+You can provide parameters for the install, per Anaconda docs at https://conda.io/docs/user-guide/install/windows.html
+  */InstallationType:[AllUsers|JustMe]
+  */AddToPath:[0|1]
+  */RegisterPython:[0|1]
+  */D:(installation path)
     </description>
     <projectUrl>https://www.continuum.io/why-anaconda</projectUrl>
     <packageSourceUrl>https://github.com/chantisnake/chocolateyPackage/tree/master/anaconda-choco/anaconda3</packageSourceUrl>

--- a/anaconda-choco/anaconda3/Versions/5.0.0/tools/chocolateyinstall.ps1
+++ b/anaconda-choco/anaconda3/Versions/5.0.0/tools/chocolateyinstall.ps1
@@ -5,6 +5,49 @@ $packageName= 'anaconda3'
 $url        = 'http://repo.continuum.io/archive/Anaconda3-5.0.0-Windows-x86.exe'
 $url64      = 'http://repo.continuum.io/archive/Anaconda3-5.0.0-Windows-x86_64.exe'
 $ToolsDir   = Get-ToolsLocation
+
+
+$pp = Get-PackageParameters
+
+if (!$pp['InstallationType']) {
+    $InstallationType = 'AllUsers'
+} else {
+    if ($pp['InstallationType'] -notin 'AllUsers','JustMe') {
+        Write-Error "Value for InstallationType not recognised: only `'AllUsers`' or `'JustMe`' are valid"
+    } else {
+        $InstallationType = $pp['InstallationType']
+    }
+}
+
+if (!$pp['RegisterPython']) {
+    $RegisterPython = '1'
+} else {
+    if ($pp['RegisterPython'] -notin '0','1') {
+        Write-Error "Value for RegisterPython not recognised: only `'0`' or `'1`' are valid"
+    } else {
+        $RegisterPython = $pp['RegisterPython']
+    }
+}
+
+if (!$pp['AddToPath']) {
+    $AddToPath = '0'
+} else {
+    if ($pp['AddToPath'] -notin '0','1') {
+        Write-Error "Value for AddToPath not recognised: only `'0`' or `'1`' are valid"
+    } else {
+        $AddToPath = $pp['AddToPath']
+    }
+}
+
+if (!$pp['D']) {
+    $D = Join-Path $ToolsDir 'Anaconda3'
+} else {
+    if (!(Test-Path -IsValid $pp['D'])) {
+        Write-Error "Value for D ($($pp['D'])) is not a valid directory path"
+    } else {
+        $D = $pp['D']
+    }
+}
  
 $packageArgs = @{
   packageName   = $packageName
@@ -12,7 +55,7 @@ $packageArgs = @{
   url           = $url
   url64bit      = $url64
  
-  silentArgs    = "/S /InstallationType=AllUsers /RegisterPython=1 /AddToPath=0 /D=$(Join-Path $ToolsDir 'Anaconda3')"
+  silentArgs    = "/S /InstallationType=$InstallationType /RegisterPython=$RegisterPython /AddToPath=$AddToPath /D=$D"
   validExitCodes= @(0)
  
   softwareName  = 'Anaconda3'

--- a/anaconda-choco/anaconda3/Versions/5.0.0/tools/chocolateyinstall.ps1
+++ b/anaconda-choco/anaconda3/Versions/5.0.0/tools/chocolateyinstall.ps1
@@ -1,4 +1,4 @@
-﻿$ErrorActionPreference = 'Stop';
+﻿$ErrorActionPreference = 'Stop'
  
  
 $packageName= 'anaconda3'
@@ -65,10 +65,10 @@ $packageArgs = @{
   checksumType64= 'sha256'
 }
  
-Write-Host 'installing anaconda3, this can take a long time, because the installer will write tons of files on your disk' -ForegroundColor Magenta
-Write-Host 'Please sit back and relax' -ForegroundColor Magenta
-Write-Host 'This usually will take 10-15 mins on an SSD, and about 30 mins on HDD' -ForegroundColor Magenta
-Write-Host ''
-Write-Host 'If you want to make sure the program is running, you can open Task Manager' -ForegroundColor Magenta
-Write-Host 'you will find the installer running in Background Process' -ForegroundColor Magenta
+Write-Warning 'installing anaconda3, this can take a long time, because the installer will write tons of files on your disk'
+Write-Warning 'Please sit back and relax'
+Write-Warning 'This usually will take 10-15 mins on an SSD, and about 30 mins on HDD'
+Write-Warning ''
+Write-Warning 'If you want to make sure the program is running, you can open Task Manager'
+Write-Warning 'you will find the installer running in Background Process'
 Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
I wanted some non-default install options, so I've added parameters to the install script (for latest version). This has been tested on Choco v0.10.8, with enterprise extension, though I've added the community core extension per the docs.

I have not been able to run them through the choco package test environment, though the changes are all in line with their guidelines.

I've made some tweaks to the description in the spec, and have tested the markdown but have no way of verifying how it will display on the Chocolatey repo.

Hope these changes are useful and can be merged in for this and future versions.